### PR TITLE
Implement state changes on backend + sync pausing

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -7,7 +7,9 @@ const startMenu = document.getElementById('startMenu');
 let isStarted = false; // Has the game begun?
 let isPaused = true;   // Is the server running?
 
-window.onload = function () {
+window.onload = function () { //Shows Start Menu at startup
+  const startMenu = document.getElementById('StartMenu');
+
   var space_bar = 32;
 
   window.onkeydown = function (key) {
@@ -24,6 +26,13 @@ window.onload = function () {
     };
   }
 };
+window.addEventListener('keydown', function(event) {
+  if(event.key === '1' && isPaused){
+    const startMenu = document.getElementById('StartMenu');
+    startMenu.style.display = 'none';
+    isPaused = false;
+  }
+});
 
 window.addEventListener('keydown', function(event) {
   if (event.key === '1' && isPaused) {

--- a/client/script.js
+++ b/client/script.js
@@ -30,6 +30,10 @@ window.addEventListener('keydown', function(event) {
     startMenu.style.display = 'none';
     isStarted = true;
     isPaused = false;
+
+    // TODO: allow client to pick the starting mass/fuel
+    socket.send("fuelMass,8200");
+    socket.send("dryMass,8200");
   }
 });
 
@@ -43,7 +47,6 @@ window.addEventListener('keydown', function(event) {
 
 //Pause Menu
 window.addEventListener('keydown', function(event) {
-
   if (!isStarted) { return; } // no pause menu until we start the game
 
   if (event.code === 'Escape') { // escape key can pause or unpause
@@ -53,6 +56,8 @@ window.addEventListener('keydown', function(event) {
     pauseMenu.style.display = 'none';
     isPaused = false;
   }
+
+  socket.send("isPaused," + isPaused);
 });
 
 // Event listener for when

--- a/client/script.js
+++ b/client/script.js
@@ -7,9 +7,7 @@ const startMenu = document.getElementById('startMenu');
 let isStarted = false; // Has the game begun?
 let isPaused = true;   // Is the server running?
 
-window.onload = function () { //Shows Start Menu at startup
-  const startMenu = document.getElementById('StartMenu');
-
+window.onload = function () {
   var space_bar = 32;
 
   window.onkeydown = function (key) {
@@ -26,10 +24,11 @@ window.onload = function () { //Shows Start Menu at startup
     };
   }
 };
+
 window.addEventListener('keydown', function(event) {
-  if(event.key === '1' && isPaused){
-    const startMenu = document.getElementById('StartMenu');
+  if (event.key === '1' && isPaused) {
     startMenu.style.display = 'none';
+    isStarted = true;
     isPaused = false;
   }
 });

--- a/client/script.js
+++ b/client/script.js
@@ -7,6 +7,32 @@ const startMenu = document.getElementById('startMenu');
 let isStarted = false; // Has the game begun?
 let isPaused = true;   // Is the server running?
 
+function stopGame() {
+  startMenu.style.display = 'flex';
+  isStarted = false;
+  isPaused = true;
+}
+
+function startGame() {
+  startMenu.style.display = 'none';
+  isStarted = true;
+  isPaused = false;
+
+  // TODO: allow client to pick the starting mass/fuel
+  socket.send("fuelMass,8200");
+  socket.send("dryMass,8200");
+}
+
+function pauseGame() {
+  pauseMenu.style.display = 'flex';
+  isPaused = true;
+}
+
+function unpauseGame() {
+  pauseMenu.style.display = 'none';
+  isPaused = false;
+}
+
 window.onload = function () {
   var space_bar = 32;
 
@@ -27,13 +53,7 @@ window.onload = function () {
 
 window.addEventListener('keydown', function(event) {
   if (event.key === '1' && isPaused) {
-    startMenu.style.display = 'none';
-    isStarted = true;
-    isPaused = false;
-
-    // TODO: allow client to pick the starting mass/fuel
-    socket.send("fuelMass,8200");
-    socket.send("dryMass,8200");
+    startGame();
   }
 });
 
@@ -50,11 +70,9 @@ window.addEventListener('keydown', function(event) {
   if (!isStarted) { return; } // no pause menu until we start the game
 
   if (event.code === 'Escape') { // escape key can pause or unpause
-    isPaused = !isPaused;
-    pauseMenu.style.display = isPaused ? 'flex' : 'none';
+    (isPaused) ? unpauseGame() : pauseGame();
   } else if (event.code === 'Enter' && isPaused) { // enter only unpauses 
-    pauseMenu.style.display = 'none';
-    isPaused = false;
+    unpauseGame();
   }
 
   socket.send("isPaused," + isPaused);
@@ -110,6 +128,9 @@ socket.onmessage = function (event) {
           }
           stats.innerHTML += `<tr><td>${statKeyFormatted}</td><td>${data}</td></tr>`;
         }
+        break;
+      case "diedLastTick":
+        stopGame();
         break;
       // Add more cases as needed for other keys
       default:

--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ const controlsMod = require('./modules/controls');
 const loggingMod = require('./modules/logging');
 const communicationMod = require('./modules/communications');
 
-const TIME_ACCELERATION = 5;
+const TIME_ACCELERATION = 1;
 
 // Time constants
 const NS_PER_MS = 1_000_000;

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,7 @@
+// npm modules
+const WebSocket = require('ws');
+
+// Custom modules
 const statisticsMod = require('./modules/statistics');
 const controlsMod = require('./modules/controls');
 const loggingMod = require('./modules/logging');
@@ -5,26 +9,34 @@ const communicationMod = require('./modules/communications');
 
 const TIME_ACCELERATION = 1;
 
+// Time constants
 const NS_PER_MS = 1_000_000;
 const MS_PER_TICK = 50;
-
 const TIME_STEP = MS_PER_TICK / 1_000;
+
+// Physical constants
 const G_0 = 9.80665;
 const LUNAR_MASS = 7.346 * 10**22;
 const LUNAR_RADIUS = 1_737_400;
 const G = 6.6743 * 10**-11;
 
+// Lander specs
+const INVALID_MASS = -1;
 const FUEL_MASS = 8_200;
 const DRY_MASS = 8_200;
 const I_SP = 311;
 const THRUST = 45_040;
 const MASS_FLOW = THRUST / G_0 / I_SP;
-
 const WARN_VEL = -3;
 const KILL_VEL = -5;
 
+// Game states
+const MENU = "menu";
+const PAUSED = "paused";
+const PLAYING = "playing";
+const GAME_END = "end";
+
 const sleep = ms => new Promise(r => setTimeout(r, ms));
-const WebSocket = require('ws');
 
 const wss = new WebSocket.Server({ port: 8080 });
 
@@ -35,9 +47,11 @@ wss.on('connection', async function connection(ws) {
   var blackboard = {
     position: 15_000 + LUNAR_RADIUS,
     velocity: 0,
-    mass: FUEL_MASS + DRY_MASS,
+    fuel_mass: FUEL_MASS,
+    dry_mass: DRY_MASS,
     isBurning: false,
-    health: 100
+    health: 100,
+    state: "menu"
   };
 
   // Holding variables. These may change many times per tick, 
@@ -45,7 +59,10 @@ wss.on('connection', async function connection(ws) {
   var holder = {
     isBurning: false,
     disconnected: false,
-    isPaused: false
+    isPaused: false,
+    fuel_mass: INVALID_MASS,
+    dry_mass: INVALID_MASS,
+    restart: false
   };
 
   // Register events
@@ -68,13 +85,51 @@ wss.on('connection', async function connection(ws) {
   });
 
   // Now that there's a connection, start the server
-  console.log(blackboard);
   statisticsMod.addAttempt(blackboard);
   while (true) {
     // Tick start
     var time = process.hrtime.bigint();
 
-    if (!holder.isPaused) {
+    // Process state changes
+    // If in the menu, move to playing and reset the blackboard once the weight has been recieved
+    // If playing, pause at will
+    // If paused, unpause at will
+    // If game ended, switch to menu on request and if so, reset the holder
+    switch (blackboard.state) {
+      case MENU:
+        // When ready, start the game and reset the blackboard
+        if (holder.fuel_mass > 0 && holder.dry_mass > 0) { 
+          blackboard.position = 15_000 + LUNAR_RADIUS;
+          blackboard.velocity = 0;
+          blackboard.fuel_mass = holder.fuel_mass;
+          blackboard.dry_mass = holder.dry_mass;
+          blackboard.isBurning = false;
+          blackboard.health = 100;
+          blackboard.state = PLAYING;
+
+          holder.isPaused = false;
+        }
+        break;
+      case PLAYING:
+        if (holder.isPaused) { blackboard.state = PAUSED; }
+        break;
+      case PAUSED:
+        if (!holder.isPaused) { blackboard.state = PLAYING; }
+        break;
+      case GAME_END:
+        if (holder.restart) { 
+          blackboard.state = MENU;
+
+          holder.isBurning = false;
+          holder.isPaused = false;
+          holder.fuel_mass = INVALID_MASS;
+          holder.dry_mass = INVALID_MASS;
+          holder.restart = false;
+        }
+        break;
+    }
+
+    if (blackboard.state == PLAYING) {
       controlsMod(blackboard, holder.isBurning);
       physicsMod(blackboard);
       statisticsMod.recordHighestAltitude(blackboard);
@@ -92,8 +147,6 @@ wss.on('connection', async function connection(ws) {
       if (holder.disconnected) { break; }
     }
   }
-
-  ws.send(JSON.stringify({stats: statisticsMod.getCurrentStats(blackboard)}));
 });
 
 /**
@@ -120,20 +173,20 @@ wss.on('connection', async function connection(ws) {
 function physicsMod(blackboard) {
   var position = blackboard.position;
   var velocity = blackboard.velocity;
-  var mass = blackboard.mass;
+  var fuel = blackboard.fuel_mass;
   var isBurning = blackboard.isBurning;
 
   let lunarG = G * LUNAR_MASS / (position**2);
   var acceleration = -lunarG;
 
   if (isBurning) {
-    mass -= MASS_FLOW * TIME_STEP;
+    fuel -= MASS_FLOW * TIME_STEP;
 
-    if (mass < DRY_MASS) {
-      mass = DRY_MASS;
+    if (fuel < 0) {
+      fuel = 0;
       isBurning = false;
     } else {
-      acceleration += THRUST / mass;
+      acceleration += THRUST / (fuel + blackboard.dry_mass);
     }
   }
 
@@ -145,21 +198,22 @@ function physicsMod(blackboard) {
 
   if (altitude <= 0){
     if (velocity < KILL_VEL) {
+
       blackboard.health = 0;
-      isDead = true;
       statisticsMod.addCrash(blackboard);
-    }
-    else if (velocity < WARN_VEL) {
+    } else if (velocity < WARN_VEL) {
+
       blackboard.health = 100 - (velocity - WARN_VEL / (KILL_VEL - WARN_VEL) * 100);
-      // FIXME: completely safe landings don't register
-      statisticsMod.addLanding(blackboard);
     }
 
+    blackboard.state = GAME_END;
     position = LUNAR_RADIUS; velocity = 0; altitude = 0;
+    statisticsMod.addLanding(blackboard);
+    ws.send(JSON.stringify({stats: statisticsMod.getCurrentStats(blackboard)}));
   }
 
   blackboard.isBurning = isBurning;
-  blackboard.mass = mass;
+  blackboard.fuel_mass = fuel;
   blackboard.position = position;
   blackboard.altitude = altitude;
   blackboard.velocity = velocity;

--- a/server/index.js
+++ b/server/index.js
@@ -92,6 +92,7 @@ wss.on('connection', async function connection(ws) {
       if (holder.disconnected) { break; }
     }
   }
+
   ws.send(JSON.stringify({stats: statisticsMod.getCurrentStats(blackboard)}));
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -92,7 +92,6 @@ wss.on('connection', async function connection(ws) {
       if (holder.disconnected) { break; }
     }
   }
-
   ws.send(JSON.stringify({stats: statisticsMod.getCurrentStats(blackboard)}));
 });
 

--- a/server/modules/communications.js
+++ b/server/modules/communications.js
@@ -5,7 +5,7 @@ function communicationMod(blackboard, ws) {
     ws.send(JSON.stringify({
         altitude: blackboard.altitude,
         velocity: blackboard.velocity,
-        mass: blackboard.mass,
+        mass: blackboard.dry_mass + blackboard.fuel_mass,
         isBurning: blackboard.isBurning,
         health: blackboard.health
     }));

--- a/server/modules/statistics.js
+++ b/server/modules/statistics.js
@@ -25,10 +25,10 @@ const StatisticsMod = {
     getCurrentStats: function (blackboard) {
         return {
             attempts: blackboard.attempts,
-            landings: blackboard.landings ?? 0,
+            landings: (blackboard.landings ?? 0) - (blackboard.crashes ?? 0),
             crashes: blackboard.crashes ?? 0,
             highestAltitude: blackboard.highestAltitude,
-            winRate: (blackboard.landings ?? 0) / blackboard.attempts,
+            winRate: 1 - (blackboard.crashes ?? 0) / blackboard.attempts,
             lossRate: (blackboard.crashes ?? 0) / blackboard.attempts
         }
     }


### PR DESCRIPTION
Now the client can pause the server, and the server can reset, updating statistics and sending the user back to the start.
Additionally, the server now accepts a weight value from the client. Right now it's hardcoded, but it should be trivial to change.

Based on and requires #94 and #83. Fixes #85, #61