### PR TITLE
Weight dropdown; restart screen fixes; star animation toggling

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -46,8 +46,8 @@
         <div class="column" id="Lander_column"></div>
         <div class="column" id="Additional_UI">
             <div id="status"></div>
-            <div id="message"></div>
-            <table id="stats"></table>
+            <!--<div id="message"></div>
+            <table id="stats"></table>-->
         </div>
     </div>
     <div id="AllStars">
@@ -65,25 +65,18 @@
     </div>
     <div id="startMenu" class="menu" style="display: flex">
         <div style="text-align: center;">
-            <h2>Eclipse</h2>
+            <h2 id="menuTitle">Eclipse</h2>
             <p>Press <strong>1</strong> to begin.</p>
             <br><br>
             <form action="">
                 <label for="cars">Select Dry weight:</label>
                 <select name="cars" id="cars">
-                  <option value="8200">Basic lander</option>
-                  <option value="9000">Lander with Rover</option>
-                  <option value="8420">Lander with Astronaut</option>
+                    <option value="8200">Basic lander</option>
+                    <option value="9000">Lander with Rover</option>
+                    <option value="8420">Lander with Astronaut</option>
                 </select>
-              </form>
-        </div>
-    </div>
-    <div id="restartMenu" class="menu">
-        <div style="text-align: center;">
-            <h2 id="message">Game over</h2>
-            <br>
+            </form>
             <table id="stats"></table>
-            <p>Press <strong>1</strong> to restart.</p>
         </div>
     </div>
     <footer></footer>

--- a/client/index.html
+++ b/client/index.html
@@ -66,8 +66,10 @@
     <div id="startMenu" class="menu" style="display: flex">
         <div style="text-align: center;">
             <h2 id="menuTitle">Eclipse</h2>
+            <div id="statsDiv">
+                <table id="stats"></table>
+            </div>
             <p>Press <strong>1</strong> to begin.</p>
-            <br><br>
             <form action="">
                 <label for="cars">Select Dry weight:</label>
                 <select name="cars" id="cars">
@@ -76,7 +78,6 @@
                     <option value="8420">Lander with Astronaut</option>
                 </select>
             </form>
-            <table id="stats"></table>
         </div>
     </div>
     <footer></footer>

--- a/client/index.html
+++ b/client/index.html
@@ -71,9 +71,9 @@
             <form action="">
                 <label for="cars">Select Dry weight:</label>
                 <select name="cars" id="cars">
-                  <option value="volvo">Basic lander</option>
-                  <option value="saab">Lander with Rover</option>
-                  <option value="opel">Lander with Astronaut</option>
+                  <option value="8200">Basic lander</option>
+                  <option value="9000">Lander with Rover</option>
+                  <option value="8420">Lander with Astronaut</option>
                 </select>
               </form>
         </div>

--- a/client/index.html
+++ b/client/index.html
@@ -67,6 +67,15 @@
         <div style="text-align: center;">
             <h2>Eclipse</h2>
             <p>Press <strong>1</strong> to begin.</p>
+            <br><br>
+            <form action="">
+                <label for="cars">Select Dry weight:</label>
+                <select name="cars" id="cars">
+                  <option value="volvo">Basic lander</option>
+                  <option value="saab">Lander with Rover</option>
+                  <option value="opel">Lander with Astronaut</option>
+                </select>
+              </form>
         </div>
     </div>
     <div id="restartMenu" class="menu">

--- a/client/index.html
+++ b/client/index.html
@@ -71,8 +71,8 @@
             </div>
             <p>Press <strong>1</strong> to begin.</p>
             <form action="">
-                <label for="cars">Select Dry weight:</label>
-                <select name="cars" id="cars">
+                <label for="landerWeight">Select Lander Configuration:</label>
+                <select name="landerWeight" id="landerWeight">
                     <option value="8200">Basic lander</option>
                     <option value="9000">Lander with Rover</option>
                     <option value="8420">Lander with Astronaut</option>

--- a/client/script.js
+++ b/client/script.js
@@ -17,12 +17,16 @@ var isConnected = false;
 
 function stopGame() {
   restartMenu.style.display = 'flex';
+  toggleAnimation();
+
   gameState = STOPPED;
 }
 
 function startGame() {
   startMenu.style.display = 'none';
   restartMenu.style.display = 'none';
+  toggleAnimation();
+  
   gameState = PLAYING;
 
   // TODO: allow client to pick the starting mass/fuel
@@ -35,6 +39,7 @@ function startGame() {
 
 function pauseGame() {
   pauseMenu.style.display = 'flex';
+  toggleAnimation();
 
   gameState = PAUSED;
   socket.send("isPaused,true");
@@ -42,6 +47,7 @@ function pauseGame() {
 
 function unpauseGame() {
   pauseMenu.style.display = 'none';
+  toggleAnimation();
 
   gameState = PLAYING;
   socket.send("isPaused,false");

--- a/client/script.js
+++ b/client/script.js
@@ -26,31 +26,31 @@ function startGame() {
   startMenu.style.display = 'none';
   restartMenu.style.display = 'none';
   toggleAnimation();
-  
-  gameState = PLAYING;
 
   // TODO: allow client to pick the starting mass/fuel
   const weightSelect = document.getElementById("cars")
   socket.send("fuelMass,8200");
   socket.send("dryMass," + weightSelect.value);
 
-  toggleAnimation();
+  gameState = PLAYING;
 }
 
 function pauseGame() {
   pauseMenu.style.display = 'flex';
   toggleAnimation();
 
-  gameState = PAUSED;
   socket.send("isPaused,true");
+
+  gameState = PAUSED;
 }
 
 function unpauseGame() {
   pauseMenu.style.display = 'none';
   toggleAnimation();
 
-  gameState = PLAYING;
   socket.send("isPaused,false");
+
+  gameState = PLAYING;
 }
 
 const startKeys = ['Escape', 'Enter', 'Digit1'];

--- a/client/script.js
+++ b/client/script.js
@@ -26,7 +26,7 @@ function startGame() {
   setAnimate(true);
 
   // TODO: allow client to pick the starting mass/fuel
-  const weightSelect = document.getElementById("cars")
+  const weightSelect = document.getElementById("landerWeight")
   socket.send("fuelMass,8200");
   socket.send("dryMass," + weightSelect.value);
 

--- a/client/script.js
+++ b/client/script.js
@@ -135,6 +135,8 @@ socket.onmessage = (event) => {
           statsHtml += `<tr><td>${statKeyFormatted}</td><td>${data}</td></tr>`;
         }
         stats.innerHTML = statsHtml;
+
+        document.getElementById("statsDiv").style.display = "flex";
         break;
       case "diedLastTick":
         stopGame();

--- a/client/script.js
+++ b/client/script.js
@@ -4,7 +4,6 @@ const socket = new WebSocket("ws://localhost:8080");
 
 const pauseMenu = document.getElementById('pauseMenu');
 const startMenu = document.getElementById('startMenu');
-const restartMenu = document.getElementById('restartMenu');
 
 // Game states
 const NOT_STARTED = 'not started';
@@ -16,16 +15,15 @@ var gameState = NOT_STARTED;
 var isConnected = false;
 
 function stopGame() {
-  restartMenu.style.display = 'flex';
-  toggleAnimation();
+  startMenu.style.display = 'flex';
+  setAnimate(false);
 
   gameState = STOPPED;
 }
 
 function startGame() {
   startMenu.style.display = 'none';
-  restartMenu.style.display = 'none';
-  toggleAnimation();
+  setAnimate(true);
 
   // TODO: allow client to pick the starting mass/fuel
   const weightSelect = document.getElementById("cars")
@@ -37,7 +35,7 @@ function startGame() {
 
 function pauseGame() {
   pauseMenu.style.display = 'flex';
-  toggleAnimation();
+  setAnimate(false);
 
   socket.send("isPaused,true");
 
@@ -46,7 +44,7 @@ function pauseGame() {
 
 function unpauseGame() {
   pauseMenu.style.display = 'none';
-  toggleAnimation();
+  setAnimate(true);
 
   socket.send("isPaused,false");
 
@@ -142,7 +140,7 @@ socket.onmessage = (event) => {
         stopGame();
         break;
       case "message":
-        const message = document.getElementById("message");
+        const message = document.getElementById("menuTitle");
         message.innerHTML = data[key];
         break;
       // Add more cases as needed for other keys

--- a/client/script.js
+++ b/client/script.js
@@ -26,8 +26,11 @@ function startGame() {
   gameState = PLAYING;
 
   // TODO: allow client to pick the starting mass/fuel
+  const weightSelect = document.getElementById("cars")
   socket.send("fuelMass,8200");
-  socket.send("dryMass,8200");
+  socket.send("dryMass," + weightSelect.value);
+
+  toggleAnimation();
 }
 
 function pauseGame() {

--- a/client/script.js
+++ b/client/script.js
@@ -65,7 +65,7 @@ window.onload = () => {
         break;
       case PLAYING:
         if (code == thrusterKey) socket.send('isBurning,true');
-        if (code == pauseKey) pauseGame();
+        else if (code == pauseKey) pauseGame();
         break;
       case PAUSED:
         if (startKeys.includes(code)) unpauseGame();

--- a/client/star.js
+++ b/client/star.js
@@ -79,11 +79,10 @@ for (var i = 0; i < starAnimation.length; i++) {
   starAnimation[i].style.animationPlayState = 'running';
 }
 
-function toggleAnimation() {
-  var style;
+function setAnimate(value) {
   for (var i = 0; i < starAnimation.length; i++) {
-    style = starAnimation[i].style;
-    if (style.animationPlayState === 'running') {
+    var style = starAnimation[i].style;
+    if (!value) {
       style.animationPlayState = 'paused';
       document.body.className = 'paused';
     } else {

--- a/client/style.css
+++ b/client/style.css
@@ -81,7 +81,8 @@ td {
 }
 
 #stats {
-  float: right;
+  margin: auto;
+  padding-top: 5px;
 }
 
 .menu {

--- a/client/style.css
+++ b/client/style.css
@@ -85,6 +85,12 @@ td {
   padding-top: 5px;
 }
 
+#statsDiv {
+  display: none;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
 .menu {
   display: none;
   position: fixed; 

--- a/server/index.js
+++ b/server/index.js
@@ -125,7 +125,7 @@ wss.on('connection', async function connection(ws) {
         if (blackboard.diedLastTick) {
           ws.send(JSON.stringify({
             stats: statisticsMod.getCurrentStats(blackboard),
-            message: `"You ${messages.death[Math.floor(Math.random() * messages.death.length)]}"`
+            message: `You ${messages.death[Math.floor(Math.random() * messages.death.length)]}`
           }));
           
           blackboard.state = MENU;


### PR DESCRIPTION
Cherry-picks commits from old branches on top of the main. Contains:
`weight-location-drop-down`
In addition, it:
- merges the start and restart screen (they don't seem to have any non-shared elements)
- hooks up star animation pausing
- hooks up the stats and messages section to the restart screen, instead of the additional UI column. I don't *know* if this was intended and can revert that if needed. I changed that because both `stats` and `messages` are in elements specified by ID, so the JS was only changing the UI bar. If the intention was to display it in both places instead, I can make it a class selector.

Fixes #122
Fixes #57 