### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+package.lock linguist-generated


### PR DESCRIPTION
Makes git statistics more accurate, by labeling certain files with extra metadata.